### PR TITLE
fix: return (String, usize) on non-supported platforms

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -150,8 +150,7 @@ jobs:
       - name: Get "Install Rust" action from neqo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
-          repository: mxinden/neqo
-          ref: rust-targets
+          repository: mozilla/neqo
           sparse-checkout: |
             .github/actions/rust
           path: neqo

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -151,7 +151,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           repository: mxinden/neqo
-          branch: rust-targets
+          ref: rust-targets
           sparse-checkout: |
             .github/actions/rust
           path: neqo

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -150,14 +150,15 @@ jobs:
       - name: Get "Install Rust" action from neqo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
-          repository: mozilla/neqo
+          repository: mxinden/neqo
+          branch: rust-targets
           sparse-checkout: |
             .github/actions/rust
           path: neqo
 
       - name: Install Rust
         uses: ./neqo/.github/actions/rust
-
-      - run: rustup target add x86_64-unknown-freebsd
+        with:
+          targets: x86_64-unknown-freebsd
 
       - run: cargo check --target x86_64-unknown-freebsd

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -140,3 +140,24 @@ jobs:
       - name: cargo-semver-checks
         if: matrix.rust-toolchain == 'stable'
         run: cargo semver-checks
+
+  check-freebsd:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Get "Install Rust" action from neqo
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: mozilla/neqo
+          sparse-checkout: |
+            .github/actions/rust
+          path: neqo
+
+      - name: Install Rust
+        uses: ./neqo/.github/actions/rust
+
+      - run: rustup target add x86_64-unknown-freebsd
+
+      - run: cargo check --target x86_64-unknown-freebsd

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,10 +105,12 @@ fn interface_and_mtu_impl(_socket: &UdpSocket) -> Result<(String, usize), Error>
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 fn interface_and_mtu_impl(socket: &UdpSocket) -> Result<(String, usize), Error> {
-    use std::ffi::{c_int, CStr};
-    use std::ptr;
     #[cfg(target_os = "linux")]
     use std::{ffi::c_char, mem, os::fd::AsRawFd};
+    use std::{
+        ffi::{c_int, CStr},
+        ptr,
+    };
 
     use libc::{
         freeifaddrs, getifaddrs, ifaddrs, in_addr_t, sockaddr_in, sockaddr_in6, AF_INET, AF_INET6,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
 use std::{
     io::{Error, ErrorKind},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket},
-    ptr,
 };
 
 // Though the module includes `allow(clippy::all)`, that doesn't seem to affect some lints
@@ -100,13 +99,14 @@ where
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-fn interface_and_mtu_impl(socket: &UdpSocket) -> Result<usize, Error> {
+fn interface_and_mtu_impl(_socket: &UdpSocket) -> Result<(String, usize), Error> {
     default_result()
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 fn interface_and_mtu_impl(socket: &UdpSocket) -> Result<(String, usize), Error> {
     use std::ffi::{c_int, CStr};
+    use std::ptr;
     #[cfg(target_os = "linux")]
     use std::{ffi::c_char, mem, os::fd::AsRawFd};
 
@@ -212,7 +212,7 @@ fn interface_and_mtu_impl(socket: &UdpSocket) -> Result<(String, usize), Error> 
 fn interface_and_mtu_impl(socket: &UdpSocket) -> Result<(String, usize), Error> {
     use std::{
         ffi::{c_void, CStr},
-        slice,
+        ptr, slice,
     };
 
     use win_bindings::{


### PR DESCRIPTION
On non-supported platforms, e.g. FreeBSD, the `mtu` crate is a no-op.

```rust
fn interface_and_mtu_impl(_socket: &UdpSocket) -> Result<(String, usize), Error> {
    default_result()
}
```

Previously the function signature was off with its unix and windows equivalents.

This commit updates the function signature and adds a CI smoke-test for FreeBSD.