### PR TITLE
ci: Run more things in parallel and only when needed

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -241,6 +241,7 @@ jobs:
           run: |
             cargo check --all-targets
             RUST_LOG=trace cargo test --no-fail-fast
+
       - if: matrix.os == 'openbsd'
         uses: vmactions/openbsd-vm@ebafa4eac4adf5e7d04e5bbb4aa764b75dd160df
         with:
@@ -251,6 +252,7 @@ jobs:
           run: |
             cargo check --all-targets
             RUST_LOG=trace cargo test --no-fail-fast
+
       - if: matrix.os == 'netbsd'
         uses: vmactions/netbsd-vm@dd0161ecbb6386e562fd098acf367633501487a4
         with:
@@ -261,6 +263,7 @@ jobs:
           run: |
             cargo check --all-targets
             RUST_LOG=trace cargo test --no-fail-fast
+
       - if: matrix.os == 'solaris'
         uses: vmactions/solaris-vm@960d7483ffd6ac03397964cf6423a2f41332c9c8
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Run tests and determine coverage
         run: |
           # shellcheck disable=SC2086
-          if [ "${{ matrix.rust-toolchain }}" == "stable" ]; then
+          if [ "${{ matrix.rust-toolchain }}" == "stable" ] && [ "${{ matrix.type }}" == "debug" ] && [ "${{endsWith(matrix.os, '-latest') && 'latest' }} == "latest" ]; then
             RUST_LOG=trace cargo +${{ matrix.rust-toolchain }} llvm-cov nextest $BUILD_TYPE --no-fail-fast --lcov --output-path lcov.info
           else
             RUST_LOG=trace cargo +${{ matrix.rust-toolchain }} nextest run $BUILD_TYPE --no-fail-fast

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -75,12 +75,18 @@ jobs:
           cargo +${{ matrix.rust-toolchain }} check $BUILD_TYPE --all-targets
 
       - name: Run tests and determine coverage
+        env:
+          RUST_LOG: trace
         run: |
           # shellcheck disable=SC2086
           if [ "${{ matrix.rust-toolchain }}" == "stable" ] && [ "${{ matrix.type }}" == "debug" ] && [ "${{endsWith(matrix.os, '-latest') && 'latest' || '' }}" == "latest" ]; then
-            RUST_LOG=trace cargo +${{ matrix.rust-toolchain }} llvm-cov nextest $BUILD_TYPE --no-fail-fast --lcov --output-path lcov.info
+            cargo +${{ matrix.rust-toolchain }} llvm-cov nextest $BUILD_TYPE --no-fail-fast --lcov --output-path lcov.info
           else
-            RUST_LOG=trace cargo +${{ matrix.rust-toolchain }} nextest run $BUILD_TYPE --no-fail-fast
+            if [ "${{ startsWith(matrix.os, 'windows') && 'windows' || '' }}" == "windows" ]; then
+              cargo +${{ matrix.rust-toolchain }} test $BUILD_TYPE --no-fail-fast
+            else
+              cargo +${{ matrix.rust-toolchain }} nextest run $BUILD_TYPE --no-fail-fast
+            fi
           fi
           cargo +${{ matrix.rust-toolchain }} bench --no-run
       - uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
@@ -95,6 +101,8 @@ jobs:
 
       - name: Run tests with sanitizers
         if: (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest') && matrix.rust-toolchain == 'nightly'
+        env:
+          RUST_LOG: trace
         run: |
           if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
             TARGET="x86_64-unknown-linux-gnu"
@@ -106,7 +114,7 @@ jobs:
           fi
           for sanitizer in $SANITIZERS; do
             echo "Running tests with $sanitizer sanitizer..."
-            RUSTFLAGS="-Z sanitizer=$sanitizer" RUSTDOCFLAGS="-Z sanitizer=$sanitizer" cargo +nightly test -Z build-std --target "$TARGET"
+            RUSTFLAGS="-Z sanitizer=$sanitizer" RUSTDOCFLAGS="-Z sanitizer=$sanitizer" cargo +nightly nextest run -Z build-std --target "$TARGET"
           done
 
   clippy:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -83,10 +83,10 @@ jobs:
             cargo +${{ matrix.rust-toolchain }} llvm-cov nextest $BUILD_TYPE --no-fail-fast --lcov --output-path lcov.info
           else
             if [ "${{ startsWith(matrix.os, 'windows') && 'windows' || '' }}" == "windows" ]; then
-              cargo +${{ matrix.rust-toolchain }} test $BUILD_TYPE --no-fail-fast
-            else
-              cargo +${{ matrix.rust-toolchain }} nextest run $BUILD_TYPE --no-fail-fast
+              # The codegen_windows_bindings only succeeds when run via llvm-cov?!
+              export EXCLUDE="--exclude codegen_windows_bindings"
             fi
+            cargo +${{ matrix.rust-toolchain }} nextest run $BUILD_TYPE --no-fail-fast $EXCLUDE
           fi
           cargo +${{ matrix.rust-toolchain }} bench --no-run
       - uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Run tests and determine coverage
         run: |
           # shellcheck disable=SC2086
-          if [ "${{ matrix.rust-toolchain }}" == "stable" ] && [ "${{ matrix.type }}" == "debug" ] && [ "${{endsWith(matrix.os, '-latest') && 'latest' }} == "latest" ]; then
+          if [ "${{ matrix.rust-toolchain }}" == "stable" ] && [ "${{ matrix.type }}" == "debug" ] && [ "${{endsWith(matrix.os, '-latest') && 'latest' || '' }}" == "latest" ]; then
             RUST_LOG=trace cargo +${{ matrix.rust-toolchain }} llvm-cov nextest $BUILD_TYPE --no-fail-fast --lcov --output-path lcov.info
           else
             RUST_LOG=trace cargo +${{ matrix.rust-toolchain }} nextest run $BUILD_TYPE --no-fail-fast

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -166,6 +166,9 @@ jobs:
       - run: cargo machete
 
   format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           repository: mozilla/neqo
@@ -196,7 +199,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - run: cargo semver-checks
-      
+
   check-vm:
     strategy:
       fail-fast: false

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -84,7 +84,7 @@ jobs:
           else
             if [ "${{ startsWith(matrix.os, 'windows') && 'windows' || '' }}" == "windows" ]; then
               # The codegen_windows_bindings only succeeds when run via llvm-cov?!
-              export EXCLUDE="-E not(codegen_windows_bindings)"
+              export EXCLUDE="-E not (test(codegen_windows_bindings))"
             fi
             cargo +${{ matrix.rust-toolchain }} nextest run $BUILD_TYPE --no-fail-fast $EXCLUDE
           fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -84,7 +84,7 @@ jobs:
           else
             if [ "${{ startsWith(matrix.os, 'windows') && 'windows' || '' }}" == "windows" ]; then
               # The codegen_windows_bindings only succeeds when run via llvm-cov?!
-              export EXCLUDE="--exclude codegen_windows_bindings"
+              export EXCLUDE="-E not(codegen_windows_bindings)"
             fi
             cargo +${{ matrix.rust-toolchain }} nextest run $BUILD_TYPE --no-fail-fast $EXCLUDE
           fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -84,7 +84,7 @@ jobs:
           else
             if [ "${{ startsWith(matrix.os, 'windows') && 'windows' || '' }}" == "windows" ]; then
               # The codegen_windows_bindings only succeeds when run via llvm-cov?!
-              export EXCLUDE="-E not (test(codegen_windows_bindings))"
+              export EXCLUDE="-E not test(codegen_windows_bindings)"
             fi
             cargo +${{ matrix.rust-toolchain }} nextest run $BUILD_TYPE --no-fail-fast $EXCLUDE
           fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -119,105 +119,6 @@ jobs:
             RUSTFLAGS="-Z sanitizer=$sanitizer" RUSTDOCFLAGS="-Z sanitizer=$sanitizer" cargo +nightly nextest run -Z build-std --target "$TARGET"
           done
 
-  clippy:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          repository: mozilla/neqo
-          sparse-checkout: |
-            .github/actions/rust
-          path: neqo
-      - uses: ./neqo/.github/actions/rust
-        with:
-          components: clippy
-          tools: cargo-hack
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - run: cargo hack clippy --all-targets --feature-powerset -- -D warnings
-      - run: cargo doc --workspace --no-deps --document-private-items
-        env:
-          RUSTDOCFLAGS: "--deny rustdoc::broken_intra_doc_links --deny warnings"
-
-  check-freebsd:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          repository: mozilla/neqo
-          sparse-checkout: |
-            .github/actions/rust
-          path: neqo
-      - uses: ./neqo/.github/actions/rust
-        with:
-          targets: x86_64-unknown-freebsd
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - run: cargo check --target x86_64-unknown-freebsd
-
-  machete:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          repository: mozilla/neqo
-          sparse-checkout: |
-            .github/actions/rust
-          path: neqo
-      - uses: ./neqo/.github/actions/rust
-        with:
-          tools: cargo-machete
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-        #  --with-metadata has false positives, see https://github.com/bnjbvr/cargo-machete/issues/127
-      - run: cargo machete
-
-
-  format:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          repository: mozilla/neqo
-          sparse-checkout: |
-            .github/actions/rust
-          path: neqo
-      - uses: ./neqo/.github/actions/rust
-        with:
-          version: nightly
-          components: rustfmt
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - run: cargo fmt --all -- --check
-
-  semver:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          repository: mozilla/neqo
-          sparse-checkout: |
-            .github/actions/rust
-          path: neqo
-      - uses: ./neqo/.github/actions/rust
-        with:
-          tools: cargo-semver-checks
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - run: cargo semver-checks
-
   check-vm:
     strategy:
       fail-fast: false
@@ -274,3 +175,85 @@ jobs:
           run: |
             cargo check --all-targets
             RUST_LOG=trace cargo test --no-fail-fast
+
+  clippy:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: mozilla/neqo
+          sparse-checkout: |
+            .github/actions/rust
+          path: neqo
+      - uses: ./neqo/.github/actions/rust
+        with:
+          components: clippy
+          tools: cargo-hack
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: cargo hack clippy --all-targets --feature-powerset -- -D warnings
+      - run: cargo doc --workspace --no-deps --document-private-items
+        env:
+          RUSTDOCFLAGS: "--deny rustdoc::broken_intra_doc_links --deny warnings"
+
+  machete:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: mozilla/neqo
+          sparse-checkout: |
+            .github/actions/rust
+          path: neqo
+      - uses: ./neqo/.github/actions/rust
+        with:
+          tools: cargo-machete
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+        #  --with-metadata has false positives, see https://github.com/bnjbvr/cargo-machete/issues/127
+      - run: cargo machete
+
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: mozilla/neqo
+          sparse-checkout: |
+            .github/actions/rust
+          path: neqo
+      - uses: ./neqo/.github/actions/rust
+        with:
+          version: nightly
+          components: rustfmt
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: cargo fmt --all -- --check
+
+  semver:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: mozilla/neqo
+          sparse-checkout: |
+            .github/actions/rust
+          path: neqo
+      - uses: ./neqo/.github/actions/rust
+        with:
+          tools: cargo-semver-checks
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: cargo semver-checks

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -84,9 +84,10 @@ jobs:
           else
             if [ "${{ startsWith(matrix.os, 'windows') && 'windows' || '' }}" == "windows" ]; then
               # The codegen_windows_bindings only succeeds when run via llvm-cov?!
-              export EXCLUDE='-E "not test(codegen_windows_bindings)"'
+              cargo +${{ matrix.rust-toolchain }} nextest run $BUILD_TYPE --no-fail-fast -E "not test(codegen_windows_bindings)"
+            else
+              cargo +${{ matrix.rust-toolchain }} nextest run $BUILD_TYPE --no-fail-fast $EXCLUDE
             fi
-            cargo +${{ matrix.rust-toolchain }} nextest run $BUILD_TYPE --no-fail-fast $EXCLUDE
           fi
           cargo +${{ matrix.rust-toolchain }} bench --no-run
       - uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -83,7 +83,7 @@ jobs:
             cargo +${{ matrix.rust-toolchain }} llvm-cov nextest $BUILD_TYPE --no-fail-fast --lcov --output-path lcov.info
           else
             if [ "${{ startsWith(matrix.os, 'windows') && 'windows' || '' }}" == "windows" ]; then
-              # The codegen_windows_bindings only succeeds when run via llvm-cov?!
+              # The codegen_windows_bindings test only succeeds when run via llvm-cov?!
               export FILTER="not test(codegen_windows_bindings)"
             else
               export FILTER="default()"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -84,7 +84,7 @@ jobs:
           else
             if [ "${{ startsWith(matrix.os, 'windows') && 'windows' || '' }}" == "windows" ]; then
               # The codegen_windows_bindings only succeeds when run via llvm-cov?!
-              export EXCLUDE="-E 'not test(codegen_windows_bindings)'"
+              export EXCLUDE='-E "not test(codegen_windows_bindings)"'
             fi
             cargo +${{ matrix.rust-toolchain }} nextest run $BUILD_TYPE --no-fail-fast $EXCLUDE
           fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,7 +20,6 @@ permissions:
 
 jobs:
   check:
-    name: Check
     strategy:
       fail-fast: false
       matrix:
@@ -55,35 +54,44 @@ jobs:
         shell: bash
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - name: Get "Install Rust" action from neqo
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           repository: mozilla/neqo
           sparse-checkout: |
             .github/actions/rust
           path: neqo
-
-      - name: Install Rust
-        uses: ./neqo/.github/actions/rust
+      - uses: ./neqo/.github/actions/rust
         with:
           version: ${{ matrix.rust-toolchain }}
-          components: rustfmt, clippy, llvm-tools-preview, ${{ matrix.rust-toolchain == 'nightly' && 'rust-src' || '' }}
-          tools: cargo-llvm-cov, cargo-nextest, cargo-hack, cargo-machete, ${{ matrix.rust-toolchain == 'stable' && 'cargo-semver-checks' || '' }}
+          components: ${{ matrix.rust-toolchain == 'stable' && 'llvm-tools-preview' || '' }} ${{ matrix.rust-toolchain == 'nightly' && 'rust-src' || '' }}
+          tools: ${{ matrix.rust-toolchain == 'stable' && 'cargo-llvm-cov, ' || '' }} cargo-nextest
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build
+      - name: Check
         run: |
           # shellcheck disable=SC2086
-          cargo +${{ matrix.rust-toolchain }} build $BUILD_TYPE --all-targets
+          cargo +${{ matrix.rust-toolchain }} check $BUILD_TYPE --all-targets
 
       - name: Run tests and determine coverage
         run: |
           # shellcheck disable=SC2086
-          RUST_LOG=trace cargo +${{ matrix.rust-toolchain }} llvm-cov nextest $BUILD_TYPE --no-fail-fast --lcov --output-path lcov.info
+          if [ "${{ matrix.rust-toolchain }}" == "stable" ]; then
+            RUST_LOG=trace cargo +${{ matrix.rust-toolchain }} llvm-cov nextest $BUILD_TYPE --no-fail-fast --lcov --output-path lcov.info
+          else
+            RUST_LOG=trace cargo +${{ matrix.rust-toolchain }} nextest run $BUILD_TYPE --no-fail-fast
+          fi
           cargo +${{ matrix.rust-toolchain }} bench --no-run
+      - uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
+        with:
+          file: lcov.info
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        if: matrix.type == 'debug' && matrix.rust-toolchain == 'stable' && endsWith(matrix.os, '-latest')
 
       - name: Run tests with sanitizers
         if: (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest') && matrix.rust-toolchain == 'nightly'
@@ -101,63 +109,101 @@ jobs:
             RUSTFLAGS="-Z sanitizer=$sanitizer" RUSTDOCFLAGS="-Z sanitizer=$sanitizer" cargo +nightly test -Z build-std --target "$TARGET"
           done
 
-      - name: Check formatting
-        run: |
-          if [ "${{ matrix.rust-toolchain }}" != "nightly" ]; then
-            CONFIG_PATH="--config-path=$(mktemp)"
-          fi
-          # shellcheck disable=SC2086
-          cargo +${{ matrix.rust-toolchain }} fmt --all -- --check $CONFIG_PATH
-        if: success() || failure()
-
-      - name: Check for unused dependencies
-        run: |
-          #  --with-metadata has false positives, see https://github.com/bnjbvr/cargo-machete/issues/127
-          cargo +${{ matrix.rust-toolchain }} machete
-
-      - name: Clippy
-        run: |
-          cargo +${{ matrix.rust-toolchain }} hack clippy --all-targets --feature-powerset -- -D warnings || ${{ matrix.rust-toolchain == 'nightly' }}
-        if: success() || failure()
-
-      - name: Check rustdoc links
-        run: cargo +${{ matrix.rust-toolchain }} doc --workspace --no-deps --document-private-items
-        env:
-          RUSTDOCFLAGS: "--deny rustdoc::broken_intra_doc_links --deny warnings"
-        if: success() || failure()
-
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
-        with:
-          file: lcov.info
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        if: matrix.type == 'debug' && matrix.rust-toolchain == 'stable' && endsWith(matrix.os, '-latest')
-
-      - name: cargo-semver-checks
-        if: matrix.rust-toolchain == 'stable'
-        run: cargo semver-checks
-
-  check-freebsd:
-    runs-on: ubuntu-latest
+  clippy:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     steps:
-      - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Get "Install Rust" action from neqo
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           repository: mozilla/neqo
           sparse-checkout: |
             .github/actions/rust
           path: neqo
+      - uses: ./neqo/.github/actions/rust
+        with:
+          components: clippy
+          tools: cargo-hack
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Rust
-        uses: ./neqo/.github/actions/rust
+      - run: cargo hack clippy --all-targets --feature-powerset -- -D warnings
+      - run: cargo doc --workspace --no-deps --document-private-items
+        env:
+          RUSTDOCFLAGS: "--deny rustdoc::broken_intra_doc_links --deny warnings"
+
+  check-freebsd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: mozilla/neqo
+          sparse-checkout: |
+            .github/actions/rust
+          path: neqo
+      - uses: ./neqo/.github/actions/rust
         with:
           targets: x86_64-unknown-freebsd
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - run: cargo check --target x86_64-unknown-freebsd
+
+  machete:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: mozilla/neqo
+          sparse-checkout: |
+            .github/actions/rust
+          path: neqo
+      - uses: ./neqo/.github/actions/rust
+        with:
+          tools: cargo-machete
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+        #  --with-metadata has false positives, see https://github.com/bnjbvr/cargo-machete/issues/127
+      - run: cargo machete
+
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: mozilla/neqo
+          sparse-checkout: |
+            .github/actions/rust
+          path: neqo
+      - uses: ./neqo/.github/actions/rust
+        with:
+          version: nightly
+          components: rustfmt
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: cargo fmt --all -- --check
+
+  semver:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: mozilla/neqo
+          sparse-checkout: |
+            .github/actions/rust
+          path: neqo
+      - uses: ./neqo/.github/actions/rust
+        with:
+          tools: cargo-semver-checks
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: cargo semver-checks

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -88,7 +88,7 @@ jobs:
             else
               export FILTER="default()"
             fi
-            cargo +${{ matrix.rust-toolchain }} nextest run $BUILD_TYPE --no-fail-fast -E $FILTER
+            cargo +${{ matrix.rust-toolchain }} nextest run $BUILD_TYPE --no-fail-fast -E "$FILTER"
           fi
           cargo +${{ matrix.rust-toolchain }} bench --no-run
       - uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -84,10 +84,11 @@ jobs:
           else
             if [ "${{ startsWith(matrix.os, 'windows') && 'windows' || '' }}" == "windows" ]; then
               # The codegen_windows_bindings only succeeds when run via llvm-cov?!
-              cargo +${{ matrix.rust-toolchain }} nextest run $BUILD_TYPE --no-fail-fast -E "not test(codegen_windows_bindings)"
+              export FILTER="not test(codegen_windows_bindings)"
             else
-              cargo +${{ matrix.rust-toolchain }} nextest run $BUILD_TYPE --no-fail-fast $EXCLUDE
+              export FILTER="default()"
             fi
+            cargo +${{ matrix.rust-toolchain }} nextest run $BUILD_TYPE --no-fail-fast -E $FILTER
           fi
           cargo +${{ matrix.rust-toolchain }} bench --no-run
       - uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -84,7 +84,7 @@ jobs:
           else
             if [ "${{ startsWith(matrix.os, 'windows') && 'windows' || '' }}" == "windows" ]; then
               # The codegen_windows_bindings only succeeds when run via llvm-cov?!
-              export EXCLUDE="-E not test(codegen_windows_bindings)"
+              export EXCLUDE="-E 'not test(codegen_windows_bindings)'"
             fi
             cargo +${{ matrix.rust-toolchain }} nextest run $BUILD_TYPE --no-fail-fast $EXCLUDE
           fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -217,3 +217,57 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - run: cargo semver-checks
+
+  check-vm:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [freebsd, openbsd, netbsd] # rust on solaris is too old
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - if: matrix.os == 'freebsd'
+        uses: vmactions/freebsd-vm@d7b8fcc7711aa41ad45e8d9b737cf90f035a7e3d
+        with:
+          usesh: true
+          copyback: false
+          prepare: |
+            mkdir -p /usr/local/etc/pkg/repos
+            sed 's/quarterly/latest/' /etc/pkg/FreeBSD.conf > /usr/local/etc/pkg/repos/FreeBSD.conf
+            pkg update
+            pkg install -y rust
+          run: |
+            cargo check --all-targets
+            RUST_LOG=trace cargo test --no-fail-fast
+      - if: matrix.os == 'openbsd'
+        uses: vmactions/openbsd-vm@ebafa4eac4adf5e7d04e5bbb4aa764b75dd160df
+        with:
+          usesh: true
+          copyback: false
+          prepare: |
+            pkg_add rust
+          run: |
+            cargo check --all-targets
+            RUST_LOG=trace cargo test --no-fail-fast
+      - if: matrix.os == 'netbsd'
+        uses: vmactions/netbsd-vm@dd0161ecbb6386e562fd098acf367633501487a4
+        with:
+          usesh: true
+          copyback: false
+          prepare: |
+            /usr/sbin/pkg_add rust
+          run: |
+            cargo check --all-targets
+            RUST_LOG=trace cargo test --no-fail-fast
+      - if: matrix.os == 'solaris'
+        uses: vmactions/solaris-vm@960d7483ffd6ac03397964cf6423a2f41332c9c8
+        with:
+          usesh: true
+          copyback: false
+          prepare: |
+            pkg install cargo
+          run: |
+            cargo check --all-targets
+            RUST_LOG=trace cargo test --no-fail-fast

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,7 +299,6 @@ fn interface_and_mtu_impl(socket: &UdpSocket) -> Result<(String, usize), Error> 
 mod test {
     use std::{
         env,
-        io::ErrorKind,
         net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket},
     };
 
@@ -341,8 +340,8 @@ mod test {
                 // We found an unused port.
                 Ok(socket) => return socket.local_addr().unwrap(),
                 Err(e) => match e.kind() {
-                    ErrorKind::AddrInUse | ErrorKind::PermissionDenied => {
-                        // We hit a used or priviledged port, try again.
+                    std::io::ErrorKind::AddrInUse => {
+                        // We hit a used port, try again.
                         continue;
                     }
                     _ => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,6 +299,7 @@ fn interface_and_mtu_impl(socket: &UdpSocket) -> Result<(String, usize), Error> 
 mod test {
     use std::{
         env,
+        io::ErrorKind,
         net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket},
     };
 
@@ -340,7 +341,7 @@ mod test {
                 // We found an unused port.
                 Ok(socket) => return socket.local_addr().unwrap(),
                 Err(e) => match e.kind() {
-                    std::io::ErrorKind::AddrInUse | std::io::ErrorKind::PermissionDenied => {
+                    ErrorKind::AddrInUse | ErrorKind::PermissionDenied => {
                         // We hit a used or priviledged port, try again.
                         continue;
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,8 +340,8 @@ mod test {
                 // We found an unused port.
                 Ok(socket) => return socket.local_addr().unwrap(),
                 Err(e) => match e.kind() {
-                    std::io::ErrorKind::AddrInUse => {
-                        // We hit a used port, try again.
+                    std::io::ErrorKind::AddrInUse | std::io::ErrorKind::PermissionDenied => {
+                        // We hit a used or priviledged port, try again.
                         continue;
                     }
                     _ => {


### PR DESCRIPTION
Similar to what was done for neqo.

Also address a spurious test failure when a privileged port was randomly chosen (since I ran a lot of tests during debugging I managed to hit that.)

TODO: Figure out why the `windows_bindgen` tests only succeeds when run via `llvm-cov`. That seems odd.