### PR TITLE
test: Pick another port on `PermissionDenied`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,6 +299,7 @@ fn interface_and_mtu_impl(socket: &UdpSocket) -> Result<(String, usize), Error> 
 mod test {
     use std::{
         env,
+        io::ErrorKind,
         net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket},
     };
 
@@ -340,8 +341,8 @@ mod test {
                 // We found an unused port.
                 Ok(socket) => return socket.local_addr().unwrap(),
                 Err(e) => match e.kind() {
-                    std::io::ErrorKind::AddrInUse => {
-                        // We hit a used port, try again.
+                    ErrorKind::AddrInUse | ErrorKind::PermissionDenied => {
+                        // We hit a used or priviledged port, try again.
                         continue;
                     }
                     _ => {


### PR DESCRIPTION
Receiving which indicates that we randomly picked a privileged port. This happens esp. on Windows, even with ports > 1024.

Broken out of #23