### PR TITLE
fix: Let the OS choose an unused local port

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/mozilla/mtu/"
 repository = "https://github.com/mozilla/mtu/"
 authors = ["The Mozilla Necko Team <necko@mozilla.com>"]
 readme = "README.md"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 # Don't increase beyond what Firefox is currently using:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/mozilla/mtu/"
 repository = "https://github.com/mozilla/mtu/"
 authors = ["The Mozilla Necko Team <necko@mozilla.com>"]
 readme = "README.md"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 # Don't increase beyond what Firefox is currently using:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,11 +6,11 @@
 
 use std::{
     io::{Error, ErrorKind},
-    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs, UdpSocket},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket},
 };
 
 // Though the module includes `allow(clippy::all)`, that doesn't seem to affect some lints
-// #[allow(clippy::semicolon_if_nothing_returned, clippy::struct_field_names)]
+#[allow(clippy::semicolon_if_nothing_returned, clippy::struct_field_names)]
 #[cfg(windows)]
 mod win_bindings;
 
@@ -29,52 +29,21 @@ pub enum SocketAddrs {
     Both((SocketAddr, SocketAddr)),
 }
 
-fn to_socket_addr<T: ToSocketAddrs>(addrs: T) -> Result<SocketAddr, Error> {
-    addrs
-        .to_socket_addrs()?
-        .next()
-        .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "No address found"))
-}
-
-impl<T> TryFrom<&(T, T)> for SocketAddrs
-where
-    T: ToSocketAddrs,
-{
-    type Error = Error;
-
-    fn try_from((local, remote): &(T, T)) -> Result<Self, Self::Error> {
-        Ok(Self::Both((
-            to_socket_addr(local)?,
-            to_socket_addr(remote)?,
-        )))
+impl From<&(SocketAddr, SocketAddr)> for SocketAddrs {
+    fn from((local, remote): &(SocketAddr, SocketAddr)) -> Self {
+        Self::Both((*local, *remote))
     }
 }
 
-impl<T> TryFrom<&(Option<T>, T)> for SocketAddrs
-where
-    T: ToSocketAddrs,
-{
-    type Error = Error;
-
-    fn try_from((local, remote): &(Option<T>, T)) -> Result<Self, Self::Error> {
-        Ok(match local {
-            Some(local) => Self::Both((to_socket_addr(local)?, to_socket_addr(remote)?)),
-            None => Self::Remote(to_socket_addr(remote)?),
-        })
+impl From<&(Option<SocketAddr>, SocketAddr)> for SocketAddrs {
+    fn from((local, remote): &(Option<SocketAddr>, SocketAddr)) -> Self {
+        local.map_or(Self::Remote(*remote), |local| Self::Both((local, *remote)))
     }
 }
 
-impl<T> TryFrom<&(T, Option<T>)> for SocketAddrs
-where
-    T: ToSocketAddrs,
-{
-    type Error = Error;
-
-    fn try_from((local, remote): &(T, Option<T>)) -> Result<Self, Self::Error> {
-        Ok(match remote {
-            Some(remote) => Self::Both((to_socket_addr(local)?, to_socket_addr(remote)?)),
-            None => Self::Local(to_socket_addr(local)?),
-        })
+impl From<&(SocketAddr, Option<SocketAddr>)> for SocketAddrs {
+    fn from((local, remote): &(SocketAddr, Option<SocketAddr>)) -> Self {
+        remote.map_or(Self::Local(*local), |remote| Self::Both((*local, remote)))
     }
 }
 
@@ -107,12 +76,9 @@ where
 /// This function returns an error if the local interface MTU cannot be determined.
 pub fn interface_and_mtu<A>(addrs: A) -> Result<(String, usize), Error>
 where
-    SocketAddrs: TryFrom<A>,
+    SocketAddrs: From<A>,
 {
-    let addrs = match SocketAddrs::try_from(addrs) {
-        Ok(addrs) => addrs,
-        Err(_e) => return Err(Error::new(ErrorKind::InvalidInput, "No address found")),
-    };
+    let addrs = SocketAddrs::from(addrs);
     let local = match addrs {
         SocketAddrs::Local(mut local) | SocketAddrs::Both((mut local, _)) => {
             // Let the OS choose an unused local port.
@@ -435,14 +401,6 @@ mod test {
         socket_with_addr(IpAddr::V6(Ipv6Addr::new(
             0x26, 0x06, 0x47, 0x00, 0x68, 0x10, 0x84, 0xe5,
         )))
-    }
-
-    #[test]
-    fn loopback_v4_ip_loopback_v4() {
-        assert_eq!(
-            interface_and_mtu(&(local_v4().ip(), local_v4())).unwrap(),
-            LOOPBACK
-        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,11 @@ where
 {
     let addrs = SocketAddrs::from(addrs);
     let local = match addrs {
-        SocketAddrs::Local(local) | SocketAddrs::Both((local, _)) => local,
+        SocketAddrs::Local(mut local) | SocketAddrs::Both((mut local, _)) => {
+            // Let the OS choose an unused local port.
+            local.set_port(0);
+            local
+        }
         SocketAddrs::Remote(remote) => SocketAddr::new(
             if remote.is_ipv4() {
                 IpAddr::V4(Ipv4Addr::UNSPECIFIED)


### PR DESCRIPTION
Because otherwise, when used with neqo, the local port is already in use for the UDP socket used for the QUIC connection.

Also cut a new release for this.