### PR TITLE
feat: Add `addr` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ license = "MIT OR Apache-2.0"
 # Also keep in sync with .github/workflows/check.yml
 rust-version = "1.76.0"
 
+[features]
+default = ["addr"]
+addr = []
+
 [dependencies]
 # Don't increase beyond what Firefox is currently using: https://searchfox.org/mozilla-central/source/Cargo.lock
 libc = { version = "0.2", default-features = false }

--- a/README.md
+++ b/README.md
@@ -4,11 +4,25 @@ A crate to return the name and maximum transmission unit (MTU) of the local netw
 
 ## Usage
 
-This crate exports a single function `interface_and_mtu` that, given a pair of local and remote `SocketAddr`s, returns the name and [maximum transmission unit (MTU)](https://en.wikipedia.org/wiki/Maximum_transmission_unit) of the local network interface used by a socket bound to the local address and connected towards the remote destination.
+### `interface_and_mtu_of_socket`
+
+This crate exports a function `interface_and_mtu_of_socket` that, given a `UdpSocket`, returns the name and [maximum transmission unit (MTU)](https://en.wikipedia.org/wiki/Maximum_transmission_unit) of the local network interface used by the socket.
+
+#### Example for `interface_and_mtu_of_socket`
+
+```rust
+let socket = std::net::UdpSocket::bind("127.0.0.1:12345").unwrap();
+let (name, mtu) = mtu::interface_and_mtu_of_socket(&socket).unwrap();
+println!("MTU is {mtu} on {name}");
+```
+
+### `interface_and_mtu`
+
+With the `addr` feature (which is enabled by default), this crate also exports a single function `interface_and_mtu` that, given a pair of local and remote `SocketAddr`s, returns the name and [maximum transmission unit (MTU)](https://en.wikipedia.org/wiki/Maximum_transmission_unit) of the local network interface used by a socket bound to the local address and connected towards the remote destination.
 
 If the local address is `None`, the function will let the operating system choose the local address based on the given remote address. If the remote address is `None`, the function will return the name and MTU of the local network interface with the given local address.
 
-## Example
+#### Example for `interface_and_mtu`
 
 ```rust
 let saddr = "127.0.0.1:443".parse().unwrap();


### PR DESCRIPTION
`interface_and_mtu` is now behind the default-on `addr` feature.

The point of this is to introduce `interface_and_mtu_of_socket`, which operates on an existing `UdpSocket`. That means we can avoid `connect`, which is blocklisted by Firefox for dependencies.

The downside is that we would need to pass in the actual `UdpSocket` to the neqo transport code, which is probably a huge pain...