### PR TITLE
fix: BSDs need different `#include`s

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/mozilla/mtu/"
 repository = "https://github.com/mozilla/mtu/"
 authors = ["The Mozilla Necko Team <necko@mozilla.com>"]
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 # Don't increase beyond what Firefox is currently using:

--- a/build.rs
+++ b/build.rs
@@ -17,10 +17,8 @@ fn bindgen() {
     let bindings = bindgen::Builder::default()
         .header_contents(
             "route.h",
-            #[cfg(target_os = "freebsd")]
+            #[cfg(any(target_os = "freebsd", target_os = "openbsd"))]
             "#include <sys/types.h>\n#include <sys/socket.h>\n#include <net/route.h>",
-            #[cfg(target_os = "openbsd")]
-            "#include <sys/types.h>\n#include <net/route.h>",
             #[cfg(not(any(target_os = "freebsd", target_os = "openbsd")))]
             "#include <net/route.h>",
         )

--- a/build.rs
+++ b/build.rs
@@ -19,7 +19,9 @@ fn bindgen() {
             "route.h",
             #[cfg(target_os = "freebsd")]
             "#include <sys/types.h>\n#include <sys/socket.h>\n#include <net/route.h>",
-            #[cfg(not(target_os = "freebsd"))]
+            #[cfg(target_os = "openbsd")]
+            "#include <sys/types.h>\n#include <net/route.h>",
+            #[cfg(not(any(target_os = "freebsd", target_os = "openbsd")))]
             "#include <net/route.h>",
         )
         // Only generate bindings for the following types

--- a/build.rs
+++ b/build.rs
@@ -17,7 +17,10 @@ fn bindgen() {
     let bindings = bindgen::Builder::default()
         .header_contents(
             "route.h",
-            "#include <sys/socket.h>\n#include <net/route.h>",
+            #[cfg(target_os = "freebsd")]
+            "#include <sys/types.h>\n#include <sys/socket.h>\n#include <net/route.h>",
+            #[cfg(not(target_os = "freebsd"))]
+            "#include <net/route.h>",
         )
         // Only generate bindings for the following types
         .allowlist_type("rt_msghdr|rt_metrics");

--- a/build.rs
+++ b/build.rs
@@ -17,7 +17,7 @@ fn bindgen() {
     let bindings = bindgen::Builder::default()
         .header_contents(
             "route.h",
-            "#include <sys/types.h>\n#include <sys/socket.h>\n#include <net/route.h>",
+            "#include <sys/socket.h>\n#include <net/route.h>",
         )
         // Only generate bindings for the following types
         .allowlist_type("rt_msghdr|rt_metrics");


### PR DESCRIPTION
Because of course they do. Old way breaks macOS Firefox build. Not sure why, given that CI here worked. 🤷 