### PR TITLE
deps: require at least libc 0.2.160

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ maintenance = { status = "actively-developed", branch = "main" }
 
 [dependencies]
 # Don't increase beyond what Firefox is currently using: https://searchfox.org/mozilla-central/source/Cargo.lock
-libc = { version = "0.2", default-features = false }
+libc = { version = "0.2.160", default-features = false }
 static_assertions = { version = "1.1", default-features = false }
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
https://github.com/mozilla/mtu/pull/29 added the following `libc` import:

``` rust
use libc::{
    freeifaddrs, getifaddrs, getpid, if_data, if_indextoname, ifaddrs, in6_addr, in_addr,
    sockaddr_in, sockaddr_in6, sockaddr_storage, AF_UNSPEC, PF_ROUTE, RTAX_MAX,
};
```

`RTAX_MAX` was added in `libc` `0.2.160`:

https://github.com/rust-lang/libc/releases/tag/0.2.160

More specifically https://github.com/rust-lang/libc/pull/3714.

This commit makes sure the above new requirement is encoded in the `mtu` `Cargo.toml` `libc` dependency declaration.

See CI failure without discussed in https://github.com/mozilla/mtu/pull/51#issuecomment-2507881053.