### PR TITLE
ci(sanitize): ignore leak in std::rt::lang_start_internal

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -141,6 +141,7 @@ jobs:
             {
               echo "leak:dyld4::RuntimeState"
               echo "leak:fetchInitializingClassList"
+              echo "leak:std::rt::lang_start_internal"
             } > suppressions.txt
             # shellcheck disable=SC2155
             export LSAN_OPTIONS="suppressions=$(pwd)/suppressions.txt"


### PR DESCRIPTION
Equivalent to https://github.com/mozilla/neqo/pull/2301.