### PR TITLE
fix(bsd): format string with format args

### DIFF
--- a/src/bsd.rs
+++ b/src/bsd.rs
@@ -187,7 +187,7 @@ fn sockaddr_len(af: AddressFamily) -> Result<usize> {
         _ => {
             return Err(Error::new(
                 ErrorKind::InvalidInput,
-                "Unsupported address family {af:?}",
+                format!("Unsupported address family {af:?}"),
             ))
         }
     };


### PR DESCRIPTION
Caught by clippy, see https://github.com/mozilla/mtu/actions/runs/12514012694/job/34909471469?pr=58.