### PR TITLE
family takes values based on IP type

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -91,7 +91,6 @@ fn bindgen() {
         "Windows.Win32.Foundation.NO_ERROR",
         "Windows.Win32.Networking.WinSock.AF_INET",
         "Windows.Win32.Networking.WinSock.AF_INET6",
-        "Windows.Win32.Networking.WinSock.AF_UNSPEC",
         "Windows.Win32.Networking.WinSock.SOCKADDR_INET",
         "Windows.Win32.NetworkManagement.IpHelper.FreeMibTable",
         "Windows.Win32.NetworkManagement.IpHelper.GetBestInterfaceEx",

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -27,7 +27,7 @@ mod bindings {
 
 use bindings::{
     if_indextoname, FreeMibTable, GetBestInterfaceEx, GetIpInterfaceTable, AF_INET, AF_INET6,
-    AF_UNSPEC, IF_MAX_STRING_SIZE, IN6_ADDR, IN6_ADDR_0, IN_ADDR, IN_ADDR_0, MIB_IPINTERFACE_ROW,
+    IF_MAX_STRING_SIZE, IN6_ADDR, IN6_ADDR_0, IN_ADDR, IN_ADDR_0, MIB_IPINTERFACE_ROW,
     MIB_IPINTERFACE_TABLE, NO_ERROR, SOCKADDR, SOCKADDR_IN, SOCKADDR_IN6, SOCKADDR_INET,
 };
 
@@ -107,7 +107,8 @@ pub fn interface_and_mtu_impl(remote: IpAddr) -> Result<(String, usize)> {
     // Get a list of all interfaces with associated metadata.
     let mut if_table = MibTablePtr::default();
     // GetIpInterfaceTable allocates memory, which MibTablePtr::drop will free.
-    if unsafe { GetIpInterfaceTable(AF_UNSPEC, if_table.mut_ptr_ptr()) } != NO_ERROR {
+    let family = if remote.is_ipv4() { AF_INET } else { AF_INET6 };
+    if unsafe { GetIpInterfaceTable(family, if_table.mut_ptr_ptr()) } != NO_ERROR {
         return Err(Error::last_os_error());
     }
     // Make a slice


### PR DESCRIPTION
On Windows, IPv6 and IPv4 can have different MTU values.