### PR TITLE
Revert " ci(sanitize): downgrade to ubuntu v22.04"

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -65,10 +65,6 @@ jobs:
           - os: windows-2019
             rust-toolchain: stable
             type: debug
-          # TODO: Remove once https://github.com/rust-lang/rust/issues/111073#issuecomment-2561607617 is fixed.
-          - os: ubuntu-22.04
-            rust-toolchain: nightly
-            type: debug
     env:
       BUILD_TYPE: ${{ matrix.type == 'release' && '--release' || '' }}
     runs-on: ${{ matrix.os }}
@@ -127,8 +123,7 @@ jobs:
         if: matrix.type == 'debug' && matrix.rust-toolchain == 'nightly' && endsWith(matrix.os, '-latest')
 
       - name: Run tests with sanitizers
-        # TODO: Unpin ubuntu when https://github.com/rust-lang/rust/issues/111073#issuecomment-2561607617 is fixed.
-        if: (matrix.os == 'ubuntu-22.04' || matrix.os == 'macos-latest') && matrix.rust-toolchain == 'nightly'
+        if: (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest') && matrix.rust-toolchain == 'nightly'
         env:
           RUST_LOG: trace
           ASAN_OPTIONS: detect_leaks=1:detect_stack_use_after_return=1


### PR DESCRIPTION
Reverts mozilla/mtu#69

See equivalent pull request https://github.com/mozilla/neqo/pull/2364 on the Neqo side.