### PR TITLE
fix: use CARGO_CFG_TARGET_OS and target_os android

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ checksum = "903970ae2f248d7275214cf8f387f8ba0c4ea7e3d87a320e85493db60ce28616"
 
 [[package]]
 name = "mtu"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "bindgen",
  "cfg_aliases",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/mozilla/mtu/"
 repository = "https://github.com/mozilla/mtu/"
 authors = ["The Mozilla Necko Team <necko@mozilla.com>"]
 readme = "README.md"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 # Don't increase beyond what Firefox is currently using:
@@ -37,8 +37,6 @@ windows = { version = ">=0.58,<0.60", features = [
 [build-dependencies]
 cfg_aliases = { version = "0.2", default-features = false }
 mozbuild = { version = "0.1", default-features = false, optional = true }
-
-[target.'cfg(not(windows))'.build-dependencies]
 # Don't increase beyond what Firefox is currently using: https://searchfox.org/mozilla-central/source/Cargo.lock
 bindgen = { version = "0.69", default-features = false, features = ["runtime"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ macro_rules! asserted_const_with_type {
 #[cfg(any(apple, bsd))]
 mod bsd;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 mod linux;
 
 #[cfg(target_os = "windows")]
@@ -71,7 +71,7 @@ mod routesocket;
 
 #[cfg(any(apple, bsd))]
 use bsd::interface_and_mtu_impl;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use linux::interface_and_mtu_impl;
 #[cfg(target_os = "windows")]
 use windows::interface_and_mtu_impl;
@@ -133,7 +133,7 @@ mod test {
 
     #[cfg(any(apple, target_os = "freebsd",))]
     const LOOPBACK: &[NameMtu] = &[NameMtu(Some("lo0"), 16_384), NameMtu(Some("lo0"), 16_384)];
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     const LOOPBACK: &[NameMtu] = &[NameMtu(Some("lo"), 65_536), NameMtu(Some("lo"), 65_536)];
     #[cfg(target_os = "windows")]
     const LOOPBACK: &[NameMtu] = &[

--- a/src/routesocket.rs
+++ b/src/routesocket.rs
@@ -15,14 +15,14 @@ use libc::{fsync, read, socket, write, SOCK_RAW};
 
 use crate::unlikely_err;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 type AtomicRouteSocketSeq = std::sync::atomic::AtomicU32;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 type RouteSocketSeq = u32;
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 type AtomicRouteSocketSeq = std::sync::atomic::AtomicI32;
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 type RouteSocketSeq = i32;
 
 static SEQ: AtomicRouteSocketSeq = AtomicRouteSocketSeq::new(0);


### PR DESCRIPTION
In a `build.rs` file `cfg(target_os = "linux")` refers to the target OS of the `build.rs` binary. The environment variable `CARGO_CFG_TARGET_OS` refers to the target OS of the final binary.

When cross-compiling, the target OS of the `build.rs` binary and the target OS of the final binary are not the same. The `mtu`'s `build.rs` should use `CARGO_CFG_TARGET_OS`.

In addition, `cfg(target_os = "linux")` does not include `android`. This commit `cfg`s `linux` and `android` everywhere.

---

Fixes https://github.com/mozilla/mtu/issues/78.