### PR TITLE
fix: drop all apple OSs but macos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ checksum = "903970ae2f248d7275214cf8f387f8ba0c4ea7e3d87a320e85493db60ce28616"
 
 [[package]]
 name = "mtu"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "bindgen",
  "cfg_aliases",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://github.com/mozilla/mtu/"
 repository = "https://github.com/mozilla/mtu/"
 authors = ["The Mozilla Necko Team <necko@mozilla.com>"]
 readme = "README.md"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 # Don't increase beyond what Firefox is currently using:

--- a/build.rs
+++ b/build.rs
@@ -44,6 +44,13 @@ const fn clang_args() -> Vec<String> {
 fn bindgen() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS was not set");
 
+    // Platforms currently not supported.
+    //
+    // See <https://github.com/mozilla/mtu/issues/82>.
+    if matches!(target_os.as_str(), "ios" | "tvos" | "visionos") {
+        return;
+    }
+
     if target_os == "windows" {
         return;
     }
@@ -91,15 +98,6 @@ fn bindgen() {
 fn main() {
     // Setup cfg aliases
     cfg_aliases::cfg_aliases! {
-        // Platforms
-        apple: {
-            any(
-                target_os = "macos",
-                target_os = "ios",
-                target_os = "tvos",
-                target_os = "visionos"
-            )
-        },
         bsd: {
             any(
                 target_os = "freebsd",

--- a/src/bsd.rs
+++ b/src/bsd.rs
@@ -41,7 +41,7 @@ use crate::{
     unlikely_err,
 };
 
-#[cfg(apple)]
+#[cfg(target_os = "macos")]
 const ALIGN: usize = std::mem::size_of::<libc::c_int>();
 
 #[cfg(bsd)]
@@ -50,7 +50,7 @@ const ALIGN: usize = std::mem::size_of::<libc::c_int>();
 // See https://github.com/Arquivotheca/Solaris-8/blob/2ad1d32f9eeed787c5adb07eb32544276e2e2444/osnet_volume/usr/src/cmd/cmd-inet/usr.sbin/route.c#L238-L239
 const ALIGN: usize = std::mem::size_of::<libc::c_long>();
 
-#[cfg(any(apple, target_os = "freebsd", target_os = "openbsd"))]
+#[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
 asserted_const_with_type!(RTM_ADDRS, i32, RTA_DST, u32);
 
 #[cfg(any(target_os = "netbsd", target_os = "solaris"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ macro_rules! asserted_const_with_type {
     };
 }
 
-#[cfg(any(apple, bsd))]
+#[cfg(any(target_os = "macos", bsd))]
 mod bsd;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -69,7 +69,7 @@ mod windows;
 #[cfg(not(target_os = "windows"))]
 mod routesocket;
 
-#[cfg(any(apple, bsd))]
+#[cfg(any(target_os = "macos", bsd))]
 use bsd::interface_and_mtu_impl;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use linux::interface_and_mtu_impl;
@@ -96,6 +96,14 @@ const fn aligned_by(size: usize, align: usize) -> usize {
     } else {
         1 + ((size - 1) | (align - 1))
     }
+}
+
+// Platforms currently not supported.
+//
+// See <https://github.com/mozilla/mtu/issues/82>.
+#[cfg(any(target_os = "ios", target_os = "tvos", target_os = "visionos"))]
+pub fn interface_and_mtu_impl(remote: IpAddr) -> Result<(String, usize)> {
+    return Err(default_err());
 }
 
 /// Return the name and maximum transmission unit (MTU) of the outgoing network interface towards a
@@ -131,7 +139,7 @@ mod test {
         }
     }
 
-    #[cfg(any(apple, target_os = "freebsd",))]
+    #[cfg(any(target_os = "macos", target_os = "freebsd",))]
     const LOOPBACK: &[NameMtu] = &[NameMtu(Some("lo0"), 16_384), NameMtu(Some("lo0"), 16_384)];
     #[cfg(any(target_os = "linux", target_os = "android"))]
     const LOOPBACK: &[NameMtu] = &[NameMtu(Some("lo"), 65_536), NameMtu(Some("lo"), 65_536)];


### PR DESCRIPTION
`net/route.h` seems to be unavailable on iOS, see #82 and various [related issue reports](https://www.google.com/search?client=ubuntu-sn&channel=fs&q=net%2Froute.h+ios).

As a hot-fix for Firefox, more specifically [bugzilla/1944802](https://bugzilla.mozilla.org/show_bug.cgi?id=1944802), I suggest dropping support for all Apple platforms, but `macos`.

Long term, we can tackle proper `ios`  support in `mtu`. Though, given that `ios` is only a tier 2 platform for Mozilla, and given that `mtu` only provides an optimization, this is not a priority.

---

Fixes https://github.com/mozilla/mtu/issues/82.