### PR TITLE
Support rtable on OpenBSD

### DIFF
--- a/src/bsd.rs
+++ b/src/bsd.rs
@@ -246,6 +246,14 @@ struct RouteMessage {
     sa: SockaddrStorage,
 }
 
+#[cfg(target_os = "openbsd")]
+fn getrtable() -> u16 {
+    extern "C" {
+        fn getrtable() -> libc::c_int;
+    }
+    unsafe { getrtable() as u16 }
+}
+
 impl RouteMessage {
     fn new(remote: IpAddr, seq: i32) -> Result<Self> {
         let sa = SockaddrStorage::from(remote);
@@ -264,6 +272,8 @@ impl RouteMessage {
                 rtm_type: RTM_GET,
                 rtm_seq: seq,
                 rtm_addrs: RTM_ADDRS,
+                #[cfg(target_os = "openbsd")]
+                rtm_tableid: getrtable(),
                 ..Default::default()
             },
             sa,

--- a/src/bsd.rs
+++ b/src/bsd.rs
@@ -252,7 +252,8 @@ fn getrtable() -> u16 {
         fn getrtable() -> libc::c_int;
     }
     #[expect(
-        clippy::cast_possible_truncation, clippy::cast_sign_loss
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
         reason = "`getrtable` returns a `c_int`."
     )]
     unsafe {

--- a/src/bsd.rs
+++ b/src/bsd.rs
@@ -251,7 +251,13 @@ fn getrtable() -> u16 {
     extern "C" {
         fn getrtable() -> libc::c_int;
     }
-    unsafe { getrtable() as u16 }
+    #[expect(
+        clippy::cast_possible_truncation, clippy::cast_sign_loss
+        reason = "`getrtable` returns a `c_int`."
+    )]
+    unsafe {
+        getrtable() as u16
+    }
 }
 
 impl RouteMessage {


### PR DESCRIPTION
OpenBSD supports multiple routing tables. The current code doesn't account for that and instead always request the route for routing table 0. If the process is run in another rtable, then this operation will get stuck. `getrtable` isn't part of `libc` crate, but part of OpenBSD's libc. The cast is safe: [the syscall never fails](https://github.com/openbsd/src/blob/master/sys/kern/uipc_syscalls.c#L1447), and the actual values are between 0 and 255.

Additional details can be found in:

- https://man.openbsd.org/rtable.4 for the mechanism in question
- https://man.openbsd.org/route.4#The_Routing_Socket for the fields in struct rt_msghdr, which includes the field that the patches set and isn't present in other BSDs
- https://man.openbsd.org/getrtable.2 for the syscall for obtaining the process' rtable