### PR TITLE
ci: `ubuntu-20` runners are retired

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -60,7 +60,7 @@ jobs:
             rust-toolchain: stable
             type: release
           # Also do some debug builds on the oldest OS versions.
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             rust-toolchain: stable
             type: debug
           - os: macos-13


### PR DESCRIPTION
Oldest is now `ubuntu-22`.