### PR TITLE
ci: `windows-2019` runner is EOL

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -66,7 +66,7 @@ jobs:
           - os: macos-13
             rust-toolchain: stable
             type: debug
-          - os: windows-2019
+          - os: windows-2022
             rust-toolchain: stable
             type: debug
     env:


### PR DESCRIPTION
Move to `windows-2022`.