### PR TITLE
ci: Turn off `--mcdc` coverage

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -111,7 +111,7 @@ jobs:
             OPTIONS+=("$BUILD_TYPE")
           fi
           if [ "$TOOLCHAIN" == "nightly" ] && [ "${{ matrix.type }}" == "debug" ]; then
-            cargo llvm-cov test --mcdc --include-ffi "${OPTIONS[@]}" --codecov --output-path codecov.json
+            cargo llvm-cov test --include-ffi "${OPTIONS[@]}" --codecov --output-path codecov.json
           else
             if [ "$WINDOWS" == "windows" ]; then
               # The codegen_windows_bindings test only succeeds when run via llvm-cov?!
@@ -304,7 +304,7 @@ jobs:
             cargo check --all-targets
             cargo clippy -- -D warnings
             cargo install cargo-llvm-cov --locked
-            cargo llvm-cov test --mcdc --include-ffi --no-fail-fast --codecov --output-path codecov.json
+            cargo llvm-cov test --include-ffi --no-fail-fast --codecov --output-path codecov.json
             cargo test --no-fail-fast --release
             rm -rf target # Don't sync this back to host
 
@@ -328,7 +328,7 @@ jobs:
             # export LLVM_COV=/usr/local/llvm19/bin/llvm-cov
             # export LLVM_PROFDATA=/usr/local/llvm19/bin/llvm-profdata
             # cargo install cargo-llvm-cov --locked
-            # cargo llvm-cov test --mcdc --include-ffi --no-fail-fast --codecov --output-path codecov.json
+            # cargo llvm-cov test --include-ffi --no-fail-fast --codecov --output-path codecov.json
             cargo test --no-fail-fast # Remove this once profiler is supported
             cargo test --no-fail-fast --release
             rm -rf target # Don't sync this back to host
@@ -352,7 +352,7 @@ jobs:
             # > error[E0463]: can't find crate for `profiler_builtins`
             # > = note: the compiler may have been built without the profiler runtime
             # cargo install cargo-llvm-cov --locked
-            # cargo llvm-cov test --mcdc --include-ffi --no-fail-fast --codecov --output-path codecov.json
+            # cargo llvm-cov test --include-ffi --no-fail-fast --codecov --output-path codecov.json
             cargo test --no-fail-fast # Remove this once profiler is supported
             cargo test --no-fail-fast --release
             rm -rf target # Don't sync this back to host
@@ -376,7 +376,7 @@ jobs:
             # > error[E0463]: can't find crate for `profiler_builtins`
             # > = note: the compiler may have been built without the profiler runtime
             # cargo install cargo-llvm-cov --locked
-            # cargo llvm-cov test --mcdc --include-ffi --no-fail-fast --codecov --output-path codecov.json
+            # cargo llvm-cov test --include-ffi --no-fail-fast --codecov --output-path codecov.json
             cargo test --no-fail-fast # Remove this once profiler is supported
             cargo test --no-fail-fast --release
             rm -rf target # Don't sync this back to host


### PR DESCRIPTION
Options around it seem to have changed, and it's of questionable benefit anyway.