### PR TITLE
 ci: Remove `--bindgen` from `cargo ndk`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -455,10 +455,10 @@ jobs:
       with:
         version: stable
         targets: ${{ matrix.target }}
-        tools: cargo-ndk
+        tools: cargo-ndk@^4
         token: ${{ secrets.GITHUB_TOKEN }}
 
-    - run: cargo ndk --bindgen -t ${{ matrix.target }} test --no-run
+    - run: cargo ndk -t ${{ matrix.target }} test --no-run
 
     - env:
         TARGET: ${{ matrix.target }}


### PR DESCRIPTION
It's now on by default in `cargo ndk` v4.
https://github.com/bbqsrc/cargo-ndk/commit/de4dcba8e3d545b87b55bd7c37ff3098717cec39

Similar to https://github.com/mozilla/neqo/pull/2817